### PR TITLE
Separate guid from podcast url

### DIFF
--- a/content/episode/000-teaser.md
+++ b/content/episode/000-teaser.md
@@ -2,7 +2,8 @@
 title: "Coming Soon"
 episode: "0"
 Description: "Podcast Driven Development is a podcast about things developers do, that aren't the code."
-podcast: "pdd-0.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-0.mp3"
+podcast: "pdd/pdd-000.mp3"
 podcast_bytes: ""
 podcast_duration: ""
 date: 2018-09-24T19:00:00+00:00

--- a/content/episode/001-continuous-integration.md
+++ b/content/episode/001-continuous-integration.md
@@ -2,7 +2,8 @@
 title: "Continuous Integration"
 episode: "1"
 Description: "Al and Andrew introduce themselves, and talk about continuous integration. What's good about it, why is it difficult, etc..."
-podcast: "pdd-1.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-1.mp3"
+podcast: "pdd/pdd-001.mp3"
 podcast_bytes: "28971257"
 podcast_duration: "00:30:10"
 date: 2018-10-31T21:00:00+00:00

--- a/content/episode/002-testing.md
+++ b/content/episode/002-testing.md
@@ -2,7 +2,8 @@
 title: "Testing"
 episode: "2"
 Description: "Al and Andrew talk about testing. What is it, why is it useful, who should do it, etc..."
-podcast: "pdd-2.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-2.mp3"
+podcast: "pdd/pdd-002.mp3"
 podcast_bytes: "27684986"
 podcast_duration: "00:43:58"
 date: 2018-11-14T00:00:00+00:00

--- a/content/episode/003-agile.md
+++ b/content/episode/003-agile.md
@@ -2,7 +2,8 @@
 title: "Agile Development"
 episode: "3"
 Description: "Al and Andrew talk about agile development. Their opinions on whether it is useful, and if so...the best ways to do it."
-podcast: "pdd-3.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-3.mp3"
+podcast: "pdd/pdd-003.mp3"
 podcast_bytes: "37049639"
 podcast_duration: "00:52:53"
 date: 2018-12-05T00:21:00+00:00

--- a/content/episode/004-coding-styles.md
+++ b/content/episode/004-coding-styles.md
@@ -2,7 +2,8 @@
 title: "Coding Styles"
 episode: "4"
 Description: "Al and Andrew talk about coding styles. Are they useful, do they enforce them, what tools do they use, and what coding styles do they use?"
-podcast: "pdd-4.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-4.mp3"
+podcast: "pdd/pdd-004.mp3"
 podcast_bytes: "30297885"
 podcast_duration: "00:42:05"
 date: 2018-12-19T21:00:00+00:00

--- a/content/episode/005-remote-working.md
+++ b/content/episode/005-remote-working.md
@@ -2,7 +2,8 @@
 title: "Remote Working"
 episode: "5"
 Description: "Al and Andrew talk about remote working. Is remote better than co-located, and how do you make communication work?"
-podcast: "pdd-5.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-5.mp3"
+podcast: "pdd/pdd-005.mp3"
 podcast_bytes: "46158993"
 podcast_duration: "00:48:05"
 date: 2019-01-30T21:00:00+00:00

--- a/content/episode/006-dev-onboarding.md
+++ b/content/episode/006-dev-onboarding.md
@@ -2,7 +2,8 @@
 title: "Developer Onboarding"
 episode: "6"
 Description: "Al and Andrew talk about developer onboarding. How do you onboard new developers and ensure they get to know the systems/processes?"
-podcast: "pdd-6.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-6.mp3"
+podcast: "pdd/pdd-006.mp3"
 podcast_bytes: "44346722"
 podcast_duration: "00:46:11"
 date: 2019-02-13T21:00:00+00:00

--- a/content/episode/007-product-management.md
+++ b/content/episode/007-product-management.md
@@ -2,7 +2,8 @@
 title: "Product Management"
 episode: "7"
 Description: "Al and Andrew talk about how we deal with managing products, how they are built, who decides what happens, and priorities."
-podcast: "pdd-7.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-7.mp3"
+podcast: "pdd/pdd-007.mp3"
 podcast_bytes: "28721318"
 podcast_duration: "00:29:55"
 date: 2019-03-27T21:00:00+00:00

--- a/content/episode/008-non-improving-devs.md
+++ b/content/episode/008-non-improving-devs.md
@@ -2,7 +2,8 @@
 title: "Devs Unwilling to Improve"
 episode: "8"
 Description: "Al and Andrew talk about how we deal with developers who don't want to learn, improve, and become better developers. Is it actually a problem?"
-podcast: "pdd-8.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-8.mp3"
+podcast: "pdd/pdd-008.mp3"
 podcast_bytes: "41744508"
 podcast_duration: "00:43:29"
 date: 2019-05-08T21:00:00+00:00

--- a/content/episode/009-careers.md
+++ b/content/episode/009-careers.md
@@ -2,7 +2,8 @@
 title: "Careers"
 episode: "9"
 Description: "Al and Andrew talk about career paths"
-podcast: "pdd-9.mp3"
+guid: "https://dts.podtrac.com/redirect.mp3/ymk.nyc3.digitaloceanspaces.com/pdd-9.mp3"
+podcast: "pdd/pdd-009.mp3"
 podcast_bytes: "29711045"
 podcast_duration: "30:56"
 date: 2019-06-05T21:00:00+00:00


### PR DESCRIPTION
Keep the old guids as the original ones they had, so podcast apps don't try to re-download. Future ones will not be the urls. This allows us to change where podcasts are stored.